### PR TITLE
feat(tui): filter sidebar to show only active subagent tasks

### DIFF
--- a/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
+++ b/packages/opencode/src/cli/cmd/tui/routes/session/sidebar.tsx
@@ -40,20 +40,26 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
         }
       }
     }
-    return Array.from(groups.entries()).map(([name, parts]) => ({
-      name,
-      parts: parts.map((part) => ({
-        id: part.id,
-        status: () => normalizeStatus(part.state.status),
-        description: () => (part.state.input?.description as string) ?? "",
-        sessionId: () => {
-          const state = part.state
-          if (state.status === "pending") return undefined
-          return (state.metadata?.sessionId as string) ?? undefined
-        },
-      })),
-    }))
+    return Array.from(groups.entries())
+      .map(([name, parts]) => ({
+        name,
+        parts: parts
+          .filter((part) => normalizeStatus(part.state.status) !== "completed")
+          .map((part) => ({
+            id: part.id,
+            status: () => normalizeStatus(part.state.status),
+            description: () => (part.state.input?.description as string) ?? "",
+            sessionId: () => {
+              const state = part.state
+              if (state.status === "pending") return undefined
+              return (state.metadata?.sessionId as string) ?? undefined
+            },
+          })),
+      }))
+      .filter((group) => group.parts.length > 0)
   })
+
+  const activeSubagentCount = createMemo(() => subagentGroups().reduce((sum, group) => sum + group.parts.length, 0))
 
   // Sort MCP servers alphabetically for consistent display order
   const mcpEntries = createMemo(() => Object.entries(sync.data.mcp).sort(([a], [b]) => a.localeCompare(b)))
@@ -135,7 +141,7 @@ export function Sidebar(props: { sessionID: string; overlay?: boolean }) {
                   <text fg={theme.text}>
                     <b>Subagents</b>
                     <Show when={!expanded.subagents}>
-                      <span style={{ fg: theme.textMuted }}> ({subagentGroups().length} types)</span>
+                      <span style={{ fg: theme.textMuted }}> ({activeSubagentCount()} active)</span>
                     </Show>
                   </text>
                 </box>


### PR DESCRIPTION
Improves the TUI sidebar UX by filtering the Subagents section to show only active tasks, preventing unbounded list growth as completed tasks accumulate.

## Changes

- Filter subagent tasks to exclude completed status
- Remove empty groups after filtering (groups with no active tasks)
- Update collapsed summary to show active count instead of total types
- Section auto-hides when no active tasks remain

## Consistency

This matches the existing Todo section pattern, which already filters to active-only items for a cleaner, more actionable view.

## Before

- Sidebar showed all subagent tasks (pending, running, completed)
- List grew indefinitely with completed items
- Collapsed view showed "X types" which wasn't very meaningful

## After

- Sidebar shows only active subagent tasks (pending, running)
- List stays clean and focused on current work
- Collapsed view shows "X active" for better clarity
- Groups with no active tasks are hidden